### PR TITLE
Delete stripe product/plans via console command

### DIFF
--- a/app/Billing/StripePlansGateway.php
+++ b/app/Billing/StripePlansGateway.php
@@ -51,8 +51,8 @@ class StripePlansGateway
     public function product()
     {
         return \Stripe\Product::create([
-            "name"                 => 'Workspace Bundle',
-            "statement_descriptor" => 'TaskMonkey Workspace',
+            "name"                 => "TaskBee Workspace Bundle",
+            "statement_descriptor" => "TaskBee Workspace",
             "type"                 => "service",
         ], ['api_key' => $this->apiKey]);
     }

--- a/app/Console/Commands/ClearStripeData.php
+++ b/app/Console/Commands/ClearStripeData.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace taskbee\Console\Commands;
+
+use Exception;
+use Illuminate\Console\Command;
+
+class ClearStripeData extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'clear:stripe-data';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = "Clear apps stripe plans and webhooks.";
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        try {
+            \Stripe\Stripe::setApiKey(config('services.stripe.secret'));
+
+            # Retrieve all TaskBee products from stripe
+            $stripeProducts = collect(\Stripe\Product::all()['data'])->filter(function ($product) {
+                return $product['name'] == 'TaskBee Workspace Bundle';
+            });
+
+            throw_if($stripeProducts->isEmpty(), new \Exception('No TaskBee products exist on Stripe.'));
+
+            # Delete the plans associated with TaskBee
+            $stripeProducts->map(function ($product) {
+                return $product['id'];
+            })->map(function ($product) {
+                return \Stripe\Plan::all(['product' => $product])['data'];
+            })->each(function ($productPlans) {
+                collect($productPlans)->each(function ($plan) {
+                    $plan->delete();
+                });
+            });
+
+            # Delete the TaskBee products
+            $stripeProducts->each->delete();
+
+            $this->info('Done');
+        } catch (\Exception $e) {
+            $this->warn($e->getMessage());
+        }
+        
+    }
+}

--- a/tests/Feature/ClearStripeDataTest.php
+++ b/tests/Feature/ClearStripeDataTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature;
+
+use Carbon\Carbon;
+use Tests\TestCase;
+use taskbee\Models\Plan;
+use taskbee\Billing\StripePlansGateway;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+/** @group integration */
+class ClearStripeDataTest extends TestCase
+{
+    /** @test */
+    function stripe_plans_are_cleared_when_command_is_called()
+    {
+        # Arrange:  Create 4 plans, 3 to be deleted and a Webhook, assert that plans exist
+        $stripeGateway = (new StripePlansGateway(config('services.stripe.secret')));
+        $created_at = Carbon::now()->unix();
+        
+        # Create Stripe Product
+        $product = $stripeGateway->product();
+        
+        # Create 4 Stripe Plans: Basic, Standard, Premium and Dummy.
+        $stripeGateway->plan(Plan::BASIC, Plan::BASIC_PRICE, Plan::BASIC_MEMBERS_LIMIT, $product);
+        $stripeGateway->plan(Plan::STANDARD, Plan::STANDARD_PRICE, Plan::STANDARD_MEMBERS_LIMIT, $product);
+        $stripeGateway->plan(Plan::PREMIUM, Plan::PREMIUM_PRICE, Plan::PREMIUM_MEMBERS_LIMIT, $product);
+        $stripeGateway->plan('Dummy Plan', '9990', '25', $product);
+    
+        # Act - clear the data
+        $this->artisan('clear:stripe-data');
+
+        # Assert: All created plans and products have been deleted
+        \Stripe\Stripe::setApiKey(config('services.stripe.secret'));
+        $stripePlans = \Stripe\Plan::all([
+            "limit" => 10,
+            "created" =>
+            [
+                "gte" => $created_at,
+            ],
+            "expand" => ['data.product']
+        ]);
+        
+        $this->assertCount(0, $stripePlans['data']);
+        $this->assertCount(0, \Stripe\Product::all(['created' => ["gte" => $created_at]])['data']);
+    }
+}

--- a/tests/Feature/ProductsAndPlansCreationTest.php
+++ b/tests/Feature/ProductsAndPlansCreationTest.php
@@ -68,7 +68,7 @@ class ProductsAndPlansCreationTest extends TestCase
             collect($stripePlans['data'])->pluck('nickname')->toArray(),
         );
 
-        // Delete the product and plans from stripe after finished test
+        # Delete the product and plans from stripe after finished test
         $product = \Stripe\Product::retrieve($stripePlans['data'][0]['product']['id']);
 
         collect($stripePlans['data'])->each(function ($plan) {


### PR DESCRIPTION
Generated product and plans belonging to the product can be deleted by calling artisan command 
`php artisan clear:stripe-data`

 Only the product and plans that belong to the app will be deleted.