### PR TITLE
Change the logic behind the member slot purchases.

### DIFF
--- a/app/Billing/StripeSubscriptionGateway.php
+++ b/app/Billing/StripeSubscriptionGateway.php
@@ -136,6 +136,8 @@ class StripeSubscriptionGateway implements SubscriptionGateway
         return \Stripe\Invoice::create([
             "customer" => $stripeSub['customer'],
             "subscription" => $stripeSub['id'],
+            "collection_method" => "send_invoice",
+            "days_until_due" => 1,
             "description" => 'Add additional member slot'
         ]);
     }

--- a/app/Http/Controllers/AddMemberSlotController.php
+++ b/app/Http/Controllers/AddMemberSlotController.php
@@ -11,7 +11,6 @@ class AddMemberSlotController extends Controller
      * Store a newly created resource in storage.
      *
      * @param \taskbee\Models\Workspace $workspace
-     * @param \taskbee\Billing\StripeSubscriptionGateway $gateway
      * @return \Illuminate\Http\Response
      */
     public function store(Workspace $workspace)

--- a/app/Http/Controllers/AddMemberSlotController.php
+++ b/app/Http/Controllers/AddMemberSlotController.php
@@ -3,7 +3,7 @@
 namespace taskbee\Http\Controllers;
 
 use taskbee\Models\Workspace;
-use taskbee\Billing\StripeSubscriptionGateway;
+use taskbee\Jobs\PurchaseSlot;
 
 class AddMemberSlotController extends Controller
 {
@@ -14,18 +14,10 @@ class AddMemberSlotController extends Controller
      * @param \taskbee\Billing\StripeSubscriptionGateway $gateway
      * @return \Illuminate\Http\Response
      */
-    public function store(Workspace $workspace, StripeSubscriptionGateway $gateway)
+    public function store(Workspace $workspace)
     {
-        $stripeSubscription = $gateway->increaseSlot($workspace);
+        PurchaseSlot::dispatch($workspace);
 
-        $invoice = $gateway->createInvoice($stripeSubscription);
-
-        # Finalize the invoice, wait for
-        # invoice payment succeeded web hook, then update the stripe subscription quantity
-        $finalizedInvoice = $invoice->finalizeInvoice();
-
-        # Customer is redirected to the stripe Hosted invoice payment page.
-        # After the successful payment, Workspace members limit is incremented, as well as WSA.
-        return response($finalizedInvoice, 200);
+        return response(['Invoice will be sent shortly to your email.'], 200);
     }
 }

--- a/app/Jobs/PurchaseSlot.php
+++ b/app/Jobs/PurchaseSlot.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace taskbee\Jobs;
+
+use Illuminate\Bus\Queueable;
+use taskbee\Models\Workspace;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use taskbee\Billing\StripeSubscriptionGateway;
+
+class PurchaseSlot implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Workspace instance.
+     * 
+     * @var \taskbee\Models\Workspace
+     */
+    protected $workspace;
+
+    /**
+     * Create a new job instance.
+     *
+     * @param \taskbee\Models\Workspace $workspace
+     */
+    public function __construct(Workspace $workspace)
+    {
+        $this->workspace = $workspace;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle(StripeSubscriptionGateway $gateway)
+    {
+        $stripeSubscription = $gateway->increaseSlot($this->workspace);
+        $invoice = $gateway->createInvoice($stripeSubscription);
+        $invoice->sendInvoice();
+    }
+}

--- a/app/Jobs/PurchaseSlot.php
+++ b/app/Jobs/PurchaseSlot.php
@@ -16,7 +16,7 @@ class PurchaseSlot implements ShouldQueue
 
     /**
      * Workspace instance.
-     * 
+     *
      * @var \taskbee\Models\Workspace
      */
     protected $workspace;
@@ -34,6 +34,7 @@ class PurchaseSlot implements ShouldQueue
     /**
      * Execute the job.
      *
+     * @param \taskbee\Billing\StripeSubscriptionGateway $gateway
      * @return void
      */
     public function handle(StripeSubscriptionGateway $gateway)

--- a/resources/js/components/MemberSlotCheckout.vue
+++ b/resources/js/components/MemberSlotCheckout.vue
@@ -43,14 +43,15 @@
       confirm() {
         Swal.fire({
           title: "Please confirm your purchase",
-          text: "You will be billed on the monthly basis and one time payment for the added member.",
+          text:
+            "You will be billed on the monthly basis and one time payment for the added member.",
           type: "info",
           showCancelButton: true,
           confirmButtonColor: "#434190",
           cancelButtonColor: "#a0aec0",
           confirmButtonText: "Yes, proceed."
         }).then(result => {
-          // If the user clicks proceed, he will be invoiced.
+          // If the user clicks proceed, he will be sent an invoice.
           if (result.value) {
             this.initStripe();
           }
@@ -64,12 +65,17 @@
         axios
           .post(`/workspaces/${this.workspace.id}/add-slot`)
           .then(response => {
-            // return a link for the hosted invoice instead of redirecting the user.
-            window.location = response.data.hosted_invoice_url;
+            // Alert user that an invoice has been sent to him, and he needs to pay for it to invite new members.
+            this.notifySubscriber(response);
           })
           .catch(error => {
             console.log(error);
           });
+      },
+
+      notifySubscriber(response) {
+        this.$toasted.show(response.data[0]);
+        this.processing = false;
       }
     }
   };

--- a/resources/js/components/Navbar.vue
+++ b/resources/js/components/Navbar.vue
@@ -33,6 +33,7 @@
       >
         <div class="mx-auto">
           <new-task-modal
+            v-show="subIsActive"
             v-if="auth.workspace_id !== null"
             class="lg:mt-0 mt-4 lg:-mr-8"
             :workspace="workspace"
@@ -70,12 +71,18 @@
 
 <script>
   export default {
-    props: ['workspace'],
+    props: ['workspace', 'subscription'],
     
     data() {
       return {
         isOpen: false,
       }
+    },
+
+    computed: {
+        subIsActive() {
+            return this.subscription.status == 'active';
+        }
     },
 
     methods: {

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -29,7 +29,11 @@
 	<body>
 		<div id="app" class="min-h-screen bg-curve">
 			@auth
-				<navbar :workspace="{{ auth()->user()->workspaceOwned() }}"></navbar>
+                <navbar 
+                    :workspace="{{ auth()->user()->workspaceOwned() }}"
+                    :subscription="{{ auth()->user()->workspaceOwned()->subscription }}"
+                >
+                </navbar>
 			@endauth
 
 			<main class="container mx-auto">

--- a/tests/Feature/StripeWebhookTest.php
+++ b/tests/Feature/StripeWebhookTest.php
@@ -59,7 +59,6 @@ class StripeWebhookTest extends TestCase
         $this->assertEquals(1, count($webhooks));
 
         # Act - find web hooks with the $endpoint
-
         # This will clear every web hook with $endpoint...
         # Use this test with caution, it will delete all your current web hooks with $endpoint.
         $this->artisan('clear:stripe-webhook');
@@ -72,6 +71,7 @@ class StripeWebhookTest extends TestCase
             return $item['url'] == config('services.ngrok.url');
         });
 
+        # Assert
         $this->assertTrue($webhooksAfterDeleting->isEmpty());
     }
 }

--- a/tests/Feature/ViewWorkspaceTest.php
+++ b/tests/Feature/ViewWorkspaceTest.php
@@ -28,15 +28,12 @@ class ViewWorkspaceTest extends TestCase
         $workspace->addMember($user);
         $response = $this->actingAs($user)->get("/workspaces/{$workspace->id}");
 
-        // $response->assertStatus(423); // locked
-        // $this->assertEquals($response->content(), 'Subscription exipred. Please renew your subscription.');
         $response->assertRedirect(route('subscription-expired.show', $workspace));
     }
 
     /** @test */
     public function workspace_members_can_see_their_own_workspace_details()
     {
-        $this->withoutExceptionHandling();
         $workspace = factory(Workspace::class)->create();
         $member = factory(User::class)->create();
         $workspace->addMember($member);


### PR DESCRIPTION
### Problem
User can click many times on purchase member slot. Stripe subscription will be increased, and he will be billed for those purchases at the end of the period. Locally, tho, he will not be able to invite a member unless he manually pays the invoice (that is sent via email)

### Possible solution
Do not update Stripe subscription until the user pays the invoice. Make a one time invoice for the amount of example $5, and send it via email. User pays for the invoice, we listen for the invoice paid event, and increase/update the users subscription.